### PR TITLE
Fix Typo in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ build_working_dir()
 
 construct_nitter_conf()
 {
-    if [ ! -f $WORKD/nitter..conf ]; then
+    if [ ! -f $WORKD/nitter.conf ]; then
 	cat /dist/nitter.conf.pre \
 	    | sed "s/REDIS_HOST/$REDIS_HOST/g" \
 	    | sed "s/REDIS_PORT/$REDIS_PORT/g" \


### PR DESCRIPTION
Hello! Thank you so much for your work, it's very useful!

Just a tiny PR to fix a typo in the entrypoint.sh.
As it is, every time you start the container it recreates/overwrites the .conf file because it "can't find it" as it's looking for the wrong name.